### PR TITLE
Fix rebuild of chooser, tabbing should now work

### DIFF
--- a/lib/chooser.js
+++ b/lib/chooser.js
@@ -284,7 +284,7 @@ exports["default"] = _react2["default"].createClass({
             var labelList = _underscore2["default"].map(options, function (item) {
                 return item.label;
             });
-            var key = labelList + "--" + choice;
+            var key = "" + labelList;
 
             // Choose the item based on label, so it will show even when there's
             // no items in the list yet
@@ -316,7 +316,7 @@ exports["default"] = _react2["default"].createClass({
             var labelList = _underscore2["default"].map(options, function (item) {
                 return item.label;
             });
-            var key = labelList + "--" + choice;
+            var key = "" + labelList;
             return _react2["default"].createElement(
                 "div",
                 { className: className, style: chooserStyle },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "moment": "^2.10.6",
     "react-addons-css-transition-group": "^0.14.3",
     "react-bootstrap": "^0.28.1",
-    "react-datepicker": "^0.15.2",
+    "react-datepicker": "^0.17.0",
     "react-select": "^0.9.1",
     "revalidator": "^0.3.1",
     "string-hash": "^1.1.0",

--- a/src/chooser.jsx
+++ b/src/chooser.jsx
@@ -267,7 +267,7 @@ export default React.createClass({
         if (searchable) {
             const options = this.getFilteredOptionList(null, this.props.limit);
             const labelList = _.map(options, (item) => item.label);
-            const key = `${labelList}--${choice}`;
+            const key = `${labelList}`;
 
             // Choose the item based on label, so it will show even when there's
             // no items in the list yet
@@ -297,7 +297,7 @@ export default React.createClass({
         } else {
             const options = this.getOptionList();
             const labelList = _.map(options, (item) => item.label);
-            const key = `${labelList}--${choice}`;
+            const key = `${labelList}`;
             return (
                 <div className={className} style={chooserStyle}>
                     <Select


### PR DESCRIPTION
DO NOT MERGE

Fixes #23

Removed the current selection from the chooser key added to the react-select widget. This should be tested in ESDB, though it works in the examples.

@srichmond Can you try this in ESDB and see if it works (point to this branch). It should fix the tabbing issue that david reported, but I'd like to know if anything breaks as a result.
