### PR TITLE
Add column based layout for form groups.

### DIFF
--- a/lib/components/Form.js
+++ b/lib/components/Form.js
@@ -152,7 +152,9 @@ var Form = function (_React$Component) {
         }
 
         if (this.props.edit === _constants.FormEditStates.TABLE) {
-          props.inline = true;
+          props.layout = _constants.FormGroupLayout.INLINE;
+        } else {
+          props.layout = this.props.groupLayout;
         }
 
         if (formFields[fieldName].disabled) {
@@ -579,7 +581,8 @@ exports.default = Form;
 Form.defaultProps = {
   formStyle: {},
   formClass: "form-horizontal",
-  formKey: "form"
+  formKey: "form",
+  groupLayout: _constants.FormGroupLayout.ROW
 };
 
 Form.propTypes = {

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -7,18 +7,24 @@ var _keymirror2 = _interopRequireDefault(_keymirror);
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 module.exports = {
-  /**
-   * At Form can either:
-   *   * ALL - Always show edit state for all of its fields
-   *   * SELECTION -  Show edit icons next to items, selecting one show edit state for that item
-   *   * NEVER - Never show edit state for the items (view only)
-   */
-  FormEditStates: (0, _keymirror2.default)({
-    ALWAYS: null,
-    SELECTED: null,
-    NEVER: null,
-    TABLE: null
-  })
+    /**
+     * At Form can either:
+     *   * ALL - Always show edit state for all of its fields
+     *   * SELECTION -  Show edit icons next to items, selecting one show edit state for that item
+     *   * NEVER - Never show edit state for the items (view only)
+     */
+    FormEditStates: (0, _keymirror2.default)({
+        ALWAYS: null,
+        SELECTED: null,
+        NEVER: null,
+        TABLE: null
+    }),
+
+    FormGroupLayout: (0, _keymirror2.default)({
+        ROW: null,
+        COLUMN: null,
+        INLINE: null
+    })
 }; /**
     *  Copyright (c) 2017, The Regents of the University of California,
     *  through Lawrence Berkeley National Laboratory (subject to receipt

--- a/lib/formGroup.js
+++ b/lib/formGroup.js
@@ -24,6 +24,8 @@ require("./components/css/group.css");
 
 require("./components/css/icon.css");
 
+var _constants = require("./constants");
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
@@ -162,13 +164,17 @@ function formGroup(Widget, hideEdit) {
           "group-label": true,
           required: required
         });
+        var marginLeft = "auto";
+        if (this.props.layout === _constants.FormGroupLayout.COLUMN) {
+          marginLeft = null;
+        }
         var fieldLabel = _react2.default.createElement(
           "div",
           {
             className: labelClasses,
             style: {
               whiteSpace: "nowrap",
-              marginLeft: "auto",
+              marginLeft: marginLeft,
               paddingTop: 3,
               color: this.state.error ? "b94a48" : "inherit"
             }
@@ -197,7 +203,7 @@ function formGroup(Widget, hideEdit) {
         }
 
         // Group
-        if (this.props.inline) {
+        if (this.props.layout === _constants.FormGroupLayout.INLINE) {
           return _react2.default.createElement(
             _flexboxReact2.default,
             {
@@ -211,6 +217,63 @@ function formGroup(Widget, hideEdit) {
               }
             },
             widget
+          );
+        } else if (this.props.layout === _constants.FormGroupLayout.COLUMN) {
+          return _react2.default.createElement(
+            _flexboxReact2.default,
+            {
+              flexDirection: "column",
+              onMouseEnter: function onMouseEnter() {
+                return _this2.handleMouseEnter();
+              },
+              onMouseLeave: function onMouseLeave() {
+                return _this2.handleMouseLeave();
+              }
+            },
+            _react2.default.createElement(
+              _flexboxReact2.default,
+              {
+                flexDirection: "row",
+                onMouseEnter: function onMouseEnter() {
+                  return _this2.handleMouseEnter();
+                },
+                onMouseLeave: function onMouseLeave() {
+                  return _this2.handleMouseLeave();
+                }
+              },
+              _react2.default.createElement(
+                _flexboxReact2.default,
+                null,
+                fieldLabel
+              ),
+              _react2.default.createElement(
+                _flexboxReact2.default,
+                { width: "25px" },
+                requiredMarker
+              )
+            ),
+            _react2.default.createElement(
+              _flexboxReact2.default,
+              {
+                flexDirection: "row",
+                onMouseEnter: function onMouseEnter() {
+                  return _this2.handleMouseEnter();
+                },
+                onMouseLeave: function onMouseLeave() {
+                  return _this2.handleMouseLeave();
+                }
+              },
+              _react2.default.createElement(
+                _flexboxReact2.default,
+                { flexGrow: 1, style: selectStyle },
+                widget
+              ),
+              _react2.default.createElement(
+                _flexboxReact2.default,
+                { width: "28px", style: selectStyle },
+                editIcon
+              )
+            )
           );
         } else {
           return _react2.default.createElement(

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.FormEditStates = exports.TagsEdit = exports.DateEdit = exports.Chooser = exports.TextArea = exports.TextEdit = exports.List = exports.formList = exports.formGroup = exports.Field = exports.Schema = exports.Form = undefined;
+exports.FormGroupLayout = exports.FormEditStates = exports.TagsEdit = exports.DateEdit = exports.Chooser = exports.TextArea = exports.TextEdit = exports.List = exports.formList = exports.formGroup = exports.Field = exports.Schema = exports.Form = undefined;
 
 var _constants = require("./constants");
 
@@ -11,6 +11,12 @@ Object.defineProperty(exports, "FormEditStates", {
   enumerable: true,
   get: function get() {
     return _constants.FormEditStates;
+  }
+});
+Object.defineProperty(exports, "FormGroupLayout", {
+  enumerable: true,
+  get: function get() {
+    return _constants.FormGroupLayout;
   }
 });
 

--- a/src/forms/components/Form.js
+++ b/src/forms/components/Form.js
@@ -15,7 +15,7 @@ import Flexbox from "flexbox-react";
 
 import Field from "./Field";
 import Schema from "./Schema";
-import { FormEditStates } from "../constants";
+import { FormEditStates, FormGroupLayout } from "../constants";
 import PropTypes from "react-immutable-proptypes";
 
 // Pass in the <Schema> element and will return all the <Fields> under it.
@@ -100,7 +100,9 @@ export default class Form extends React.Component {
       }
 
       if (this.props.edit === FormEditStates.TABLE) {
-        props.inline = true;
+        props.layout = FormGroupLayout.INLINE;
+      } else {
+        props.layout = this.props.groupLayout;
       }
 
       if (formFields[fieldName].disabled) {
@@ -492,7 +494,8 @@ export default class Form extends React.Component {
 Form.defaultProps = {
   formStyle: {},
   formClass: "form-horizontal",
-  formKey: "form"
+  formKey: "form",
+  groupLayout: FormGroupLayout.ROW
 };
 
 Form.propTypes = {

--- a/src/forms/constants.js
+++ b/src/forms/constants.js
@@ -22,5 +22,11 @@ module.exports = {
         SELECTED: null,
         NEVER: null,
         TABLE: null
+    }),
+
+    FormGroupLayout: keymirror({
+        ROW: null,
+        COLUMN: null,
+        INLINE: null
     })
 };

--- a/src/forms/formGroup.js
+++ b/src/forms/formGroup.js
@@ -15,6 +15,8 @@ import React from "react";
 import "./components/css/group.css";
 import "./components/css/icon.css";
 
+import { FormGroupLayout } from "./constants";
+
 /**
  * Groups are intended to be used within the `Form` and provide a shorthand
  * method of adding a widget and its label to a form, including support for
@@ -115,12 +117,16 @@ export default function formGroup(Widget, hideEdit) {
         "group-label": true,
         required
       });
+      let marginLeft = "auto";
+      if (this.props.layout === FormGroupLayout.COLUMN) {
+        marginLeft = null;
+      }
       const fieldLabel = (
         <div
           className={labelClasses}
           style={{
             whiteSpace: "nowrap",
-            marginLeft: "auto",
+            marginLeft,
             paddingTop: 3,
             color: this.state.error ? "b94a48" : "inherit"
           }}
@@ -152,7 +158,7 @@ export default function formGroup(Widget, hideEdit) {
       }
 
       // Group
-      if (this.props.inline) {
+      if (this.props.layout === FormGroupLayout.INLINE) {
         return (
           <Flexbox
             flexDirection="column"
@@ -161,6 +167,39 @@ export default function formGroup(Widget, hideEdit) {
             onMouseLeave={() => this.handleMouseLeave()}
           >
             {widget}
+          </Flexbox>
+        );
+      } else if (this.props.layout === FormGroupLayout.COLUMN) {
+        return (
+          <Flexbox
+            flexDirection="column"
+            onMouseEnter={() => this.handleMouseEnter()}
+            onMouseLeave={() => this.handleMouseLeave()}
+          >
+            <Flexbox
+              flexDirection="row"
+              onMouseEnter={() => this.handleMouseEnter()}
+              onMouseLeave={() => this.handleMouseLeave()}
+            >
+              <Flexbox>
+                {fieldLabel}
+              </Flexbox>
+              <Flexbox width="25px">
+                {requiredMarker}
+              </Flexbox>
+            </Flexbox>
+            <Flexbox
+              flexDirection="row"
+              onMouseEnter={() => this.handleMouseEnter()}
+              onMouseLeave={() => this.handleMouseLeave()}
+            >
+              <Flexbox flexGrow={1} style={selectStyle}>
+                {widget}
+              </Flexbox>
+              <Flexbox width="28px" style={selectStyle}>
+                {editIcon}
+              </Flexbox>
+            </Flexbox>
           </Flexbox>
         );
       } else {

--- a/src/forms/index.js
+++ b/src/forms/index.js
@@ -19,4 +19,4 @@ export TextArea from "./components/TextArea";
 export Chooser from "./components/Chooser.js";
 export DateEdit from "./components/DateEdit";
 export TagsEdit from "./components/TagsEdit";
-export { FormEditStates } from "./constants";
+export { FormEditStates, FormGroupLayout } from "./constants";


### PR DESCRIPTION
This updates the layout of the forms to have the option of being columnar format making it
more mobile friendly.  The original row format is still the default.  Controlling the layout is accomplished by setting the `groupLayout` prop for the form.

The column layout is two rows of two colums apiece.

```
| label           | required marker |
| widget                | edit icon |
```

This probably needs a little refinement.  @pjm17971 any thoughts?