### PR TITLE
inline form editing update

### DIFF
--- a/packages/react-dynamic-forms/lib/components/Form.js
+++ b/packages/react-dynamic-forms/lib/components/Form.js
@@ -288,6 +288,7 @@ var Form = function (_React$Component) {
                         if (_this3.props.onErrorCountChange) {
                             _this3.props.onErrorCountChange(_this3.props.name, errorCount, errorFields);
                         }
+                        _this3._pendingErrors = null;
                     }
 
                     // On change callback
@@ -586,7 +587,8 @@ exports.default = Form;
 
 
 Form.propTypes = {
-    value: _propTypes2.default.object
+    value: _propTypes2.default.object,
+    initialValue: _propTypes2.default.object
 };
 
 Form.defaultProps = {

--- a/packages/react-dynamic-forms/lib/components/Form.js
+++ b/packages/react-dynamic-forms/lib/components/Form.js
@@ -157,6 +157,7 @@ var Form = function (_React$Component) {
                 }
 
                 if (this.props.edit === _constants.FormEditStates.TABLE) {
+                    props.allowEdit = false;
                     props.layout = _constants.FormGroupLayout.INLINE;
                 } else {
                     props.layout = this.props.groupLayout;
@@ -180,9 +181,10 @@ var Form = function (_React$Component) {
                 props.validation = formRules[fieldName].validation;
             }
 
-            // Field value
+            // Field value (current and initial)
             if (this.props.value.has(fieldName)) {
                 props.value = this.props.value.get(fieldName);
+                props.initialValue = this.props.initialValue ? this.props.initialValue.get(fieldName) : null;
             }
 
             // Callbacks

--- a/packages/react-dynamic-forms/lib/components/List.js
+++ b/packages/react-dynamic-forms/lib/components/List.js
@@ -63,13 +63,28 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 var List = function (_React$Component) {
     _inherits(List, _React$Component);
 
-    function List() {
+    function List(props) {
         _classCallCheck(this, List);
 
-        return _possibleConstructorReturn(this, (List.__proto__ || Object.getPrototypeOf(List)).apply(this, arguments));
+        var _this = _possibleConstructorReturn(this, (List.__proto__ || Object.getPrototypeOf(List)).call(this, props));
+
+        _this.state = {
+            hover: false
+        };
+        return _this;
     }
 
     _createClass(List, [{
+        key: "handleMouseEnter",
+        value: function handleMouseEnter() {
+            this.setState({ hover: true });
+        }
+    }, {
+        key: "handleMouseLeave",
+        value: function handleMouseLeave() {
+            this.setState({ hover: false });
+        }
+    }, {
         key: "addItem",
         value: function addItem() {
             if (this.props.onAddItem) {
@@ -91,6 +106,14 @@ var List = function (_React$Component) {
             }
         }
     }, {
+        key: "revertItem",
+        value: function revertItem(index) {
+            if (this.props.onRevertItem) {
+                this.props.onRevertItem(index);
+                this.selectItem(null);
+            }
+        }
+    }, {
         key: "handleDeselect",
         value: function handleDeselect() {
             this.selectItem(null);
@@ -104,10 +127,12 @@ var List = function (_React$Component) {
             var addMinus = this.props.canRemoveItems;
             var addEdit = this.props.canEditItems;
 
+            var mouseOver = this.state.hover;
+
             // Plus [+] icon
-            var plus = void 0;
-            if (addPlus) {
-                plus = _react2.default.createElement("i", {
+            var plusIcon = void 0;
+            if (addPlus && mouseOver) {
+                plusIcon = _react2.default.createElement("i", {
                     key: "plus",
                     className: "glyphicon glyphicon-plus icon add-action",
                     onClick: function onClick() {
@@ -115,8 +140,11 @@ var List = function (_React$Component) {
                     }
                 });
             } else {
-                plus = _react2.default.createElement("div", null);
+                plusIcon = _react2.default.createElement("div", null);
             }
+
+            var LISTWIDTH = 600;
+            var ICONWIDTH = 28;
 
             // Build the item list, which is a list of table rows, each row containing
             // an item and a [-] icon used for removing that item.
@@ -142,107 +170,179 @@ var List = function (_React$Component) {
                     isEditable = true;
                 }
                 if (isEditable) {
-                    if (addMinus && !itemMinusHide) {
+                    if (addMinus && !itemMinusHide && mouseOver) {
                         minus = _react2.default.createElement("i", {
                             id: index,
                             key: minusActionKey,
-                            className: "glyphicon glyphicon-remove hostile_icon delete-action",
-                            onClick: function onClick() {
-                                return _this2.removeItem(index);
-                            }
+                            className: "glyphicon glyphicon-remove hostile_icon delete-action"
                         });
                     } else {
                         listEditItemClass += " no-controls";
                         minus = _react2.default.createElement("div", { className: "icon delete-action" });
                     }
 
-                    var flip = {
-                        transform: "scaleX(-1)",
-                        fontSize: 10
-                    };
-
                     // Edit item icon
-                    if (addEdit) {
-                        if (isBeingEdited) {
-                            edit = _react2.default.createElement("i", {
-                                id: index,
-                                key: minusActionKey,
-                                className: "glyphicon glyphicon-chevron-down icon edit-action active",
-                                onClick: function onClick() {
-                                    return _this2.selectItem(index);
-                                }
-                            });
-                        } else {
-                            edit = _react2.default.createElement("i", {
-                                id: index,
-                                key: minusActionKey,
-                                style: flip,
-                                className: "glyphicon glyphicon-chevron-left icon edit-action",
-                                onClick: function onClick() {
-                                    return _this2.selectItem(index);
-                                }
-                            });
-                        }
+                    if (addEdit && mouseOver) {
+                        edit = _react2.default.createElement("i", {
+                            id: index,
+                            key: minusActionKey,
+                            style: { paddingLeft: 5, paddingRight: 5 },
+                            className: "glyphicon glyphicon-pencil icon edit-action active"
+                        });
                     }
                 }
 
                 var minusAction = addMinus ? _react2.default.createElement(
                     _flexboxReact2.default,
-                    { width: "28px" },
-                    _react2.default.createElement(
-                        "span",
-                        { key: actionSpanKey, className: "icon", style: { background: "white" } },
-                        minus
-                    )
-                ) : _react2.default.createElement("div", null);
-
-                var editAction = addEdit ? _react2.default.createElement(
-                    _flexboxReact2.default,
-                    { width: "28px" },
+                    { width: "28px", onClick: function onClick() {
+                            return _this2.removeItem(index);
+                        } },
                     _react2.default.createElement(
                         "span",
                         {
                             key: actionSpanKey,
                             className: "icon",
-                            style: { background: "white", verticalAlign: "top" }
+                            style: { paddingLeft: 5, paddingRight: 5 }
                         },
+                        minus
+                    )
+                ) : _react2.default.createElement("div", { style: { height: 30 } });
+
+                var editAction = addEdit ? _react2.default.createElement(
+                    _flexboxReact2.default,
+                    {
+                        width: "28px",
+                        onClick: function onClick() {
+                            _this2.selectItem(index);
+                        }
+                    },
+                    _react2.default.createElement(
+                        "span",
+                        { key: actionSpanKey, className: "icon", style: { verticalAlign: "top" } },
                         edit
                     )
                 ) : _react2.default.createElement("div", null);
 
+                var doneStyle = {
+                    padding: 5,
+                    marginRight: 5,
+                    marginBottom: 5,
+                    borderStyle: "solid",
+                    borderWidth: 1,
+                    borderColor: "#b5b5b5",
+                    borderRadius: 2,
+                    color: "steelblue",
+                    cursor: "pointer"
+                };
+
+                var cancelStyle = {
+                    padding: 5,
+                    marginRight: 5,
+                    marginBottom: 5,
+                    borderStyle: "solid",
+                    borderWidth: 1,
+                    borderColor: "#b5b5b5",
+                    borderRadius: 2,
+                    color: "#AAA",
+                    cursor: "pointer"
+                };
+
                 // JSX for each row, includes: UI Item and [x] remove item button
-                return _react2.default.createElement(
-                    "li",
-                    {
-                        height: "80px",
-                        key: itemKey,
-                        className: "esnet-forms-list-item",
-                        style: {
-                            borderBottomStyle: "solid",
-                            borderBottomColor: "#DDD",
-                            borderBottomWidth: 1
-                        }
-                    },
-                    _react2.default.createElement(
-                        _flexboxReact2.default,
-                        { flexDirection: "row" },
-                        minusAction,
-                        editAction,
+
+                if (!isBeingEdited) {
+                    return _react2.default.createElement(
+                        "li",
+                        {
+                            height: "80px",
+                            width: "600px",
+                            key: itemKey,
+                            className: "esnet-forms-list-item",
+                            style: {
+                                borderBottomStyle: "solid",
+                                borderBottomColor: "#DDD",
+                                borderBottomWidth: 1
+                            }
+                        },
                         _react2.default.createElement(
                             _flexboxReact2.default,
-                            { flexGrow: 1 },
+                            { flexDirection: "row", style: { width: "100%", paddingTop: 5 } },
                             _react2.default.createElement(
-                                "span",
-                                { key: itemSpanKey, className: listEditItemClass },
-                                item
-                            )
+                                _flexboxReact2.default,
+                                { style: { width: LISTWIDTH - ICONWIDTH * 2 } },
+                                _react2.default.createElement(
+                                    "span",
+                                    { key: itemSpanKey, className: listEditItemClass },
+                                    item
+                                )
+                            ),
+                            minusAction,
+                            editAction
                         )
-                    )
-                );
+                    );
+                } else {
+                    return _react2.default.createElement(
+                        "li",
+                        {
+                            height: "80px",
+                            key: itemKey,
+                            className: "esnet-forms-list-item",
+                            style: {
+                                borderBottomStyle: "solid",
+                                borderBottomColor: "#DDD",
+                                borderBottomWidth: 1
+                            }
+                        },
+                        _react2.default.createElement(
+                            _flexboxReact2.default,
+                            {
+                                flexDirection: "row",
+                                style: { width: "100%", paddingTop: 10, paddingBottom: 10 }
+                            },
+                            _react2.default.createElement(
+                                _flexboxReact2.default,
+                                { flexDirection: "column" },
+                                _react2.default.createElement(
+                                    _flexboxReact2.default,
+                                    { style: { width: LISTWIDTH - ICONWIDTH * 2 } },
+                                    _react2.default.createElement(
+                                        "span",
+                                        { key: itemSpanKey, className: listEditItemClass },
+                                        item
+                                    )
+                                ),
+                                _react2.default.createElement(
+                                    _flexboxReact2.default,
+                                    {
+                                        style: { fontSize: 12, marginLeft: _this2.props.buttonIndent }
+                                    },
+                                    _react2.default.createElement(
+                                        "span",
+                                        { style: doneStyle, onClick: function onClick() {
+                                                return _this2.handleDeselect();
+                                            } },
+                                        "DONE"
+                                    ),
+                                    _react2.default.createElement(
+                                        "span",
+                                        {
+                                            style: cancelStyle,
+                                            onClick: function onClick() {
+                                                return _this2.revertItem(index);
+                                            }
+                                        },
+                                        "REVERT"
+                                    )
+                                )
+                            ),
+                            minusAction
+                        )
+                    );
+                }
             });
 
             // Build the [+] elements
-            if (addPlus) {
+            var plus = void 0;
+            if (addPlus && mouseOver) {
                 if (this.props.plusElement) {
                     plus = this.props.plusElement;
                 } else {
@@ -257,17 +357,49 @@ var List = function (_React$Component) {
                                 {
                                     key: "plus",
                                     className: "icon",
-                                    style: { background: "white", verticalAlign: "top", fontSize: 10 }
+                                    style: { verticalAlign: "top", fontSize: 10 }
                                 },
-                                plus
+                                plusIcon
                             )
                         ),
                         _react2.default.createElement(_flexboxReact2.default, { width: "28px" })
                     );
                 }
             } else {
-                plus = _react2.default.createElement("div", null);
+                plus = _react2.default.createElement("div", { style: { height: 35 } });
             }
+
+            //
+            // Build the header
+            //
+
+            var headerStyle = {
+                fontSize: 11,
+                paddingTop: 3,
+                height: 20,
+                color: "#9a9a9a",
+                borderBottom: "#ddd",
+                borderBottomStyle: "solid",
+                borderBottomWidth: 1
+            };
+
+            var headerItems = _underscore2.default.map(this.props.header, function (size, label) {
+                return _react2.default.createElement(
+                    _flexboxReact2.default,
+                    { width: size + "px" },
+                    _react2.default.createElement(
+                        "span",
+                        { style: { verticalAlign: "top", fontSize: 10, paddingLeft: 3 } },
+                        label
+                    )
+                );
+            });
+
+            var header = this.props.header ? _react2.default.createElement(
+                _flexboxReact2.default,
+                { flexDirection: "row", style: headerStyle },
+                headerItems
+            ) : _react2.default.createElement("div", null);
 
             //
             // Build the table of item rows, with the [+] at the bottom if required
@@ -277,11 +409,19 @@ var List = function (_React$Component) {
                 "div",
                 {
                     style: {
+                        width: 600,
                         borderTopStyle: "solid",
                         borderTopWidth: 1,
                         borderTopColor: "#DDD"
+                    },
+                    onMouseEnter: function onMouseEnter() {
+                        return _this2.handleMouseEnter();
+                    },
+                    onMouseLeave: function onMouseLeave() {
+                        return _this2.handleMouseLeave();
                     }
                 },
+                header,
                 _react2.default.createElement(
                     "ul",
                     { className: "esnet-forms-listeditview-container" },

--- a/packages/react-dynamic-forms/lib/components/TextEdit.js
+++ b/packages/react-dynamic-forms/lib/components/TextEdit.js
@@ -52,12 +52,28 @@ var TextEdit = function (_React$Component) {
         var _this = _possibleConstructorReturn(this, (TextEdit.__proto__ || Object.getPrototypeOf(TextEdit)).call(this, props));
 
         _this.state = {
+            hover: false,
             touched: false
         };
         return _this;
     }
 
     _createClass(TextEdit, [{
+        key: "handleMouseEnter",
+        value: function handleMouseEnter() {
+            this.setState({ hover: true });
+        }
+    }, {
+        key: "handleMouseLeave",
+        value: function handleMouseLeave() {
+            this.setState({ hover: false });
+        }
+    }, {
+        key: "handleEditItem",
+        value: function handleEditItem() {
+            this.props.onEditItem(this.props.name);
+        }
+    }, {
         key: "isEmpty",
         value: function isEmpty(value) {
             return _underscore2.default.isNull(value) || _underscore2.default.isUndefined(value) || value === "";
@@ -216,6 +232,10 @@ var TextEdit = function (_React$Component) {
                 validationError = _getError4.validationError,
                 validationErrorMessage = _getError4.validationErrorMessage;
 
+            var iconStyle = {
+                fontSize: 11
+            };
+
             if (this.props.edit) {
                 // Error style/message
                 var className = "";
@@ -259,16 +279,46 @@ var TextEdit = function (_React$Component) {
                 );
             } else {
                 var view = this.props.view;
-                var text = this.props.value;
+                var text = _react2.default.createElement(
+                    "span",
+                    null,
+                    this.props.value
+                );
                 if (isMissing) {
-                    text = " ";
+                    text = _react2.default.createElement("span", null);
                 }
+
+                var editAction = _react2.default.createElement("span", null);
+                if (this.state.hover && this.props.allowEdit) {
+                    editAction = _react2.default.createElement(
+                        "span",
+                        { style: { marginLeft: 5 }, onClick: function onClick() {
+                                return _this2.handleEditItem();
+                            } },
+                        _react2.default.createElement("i", {
+                            style: iconStyle,
+                            className: "glyphicon glyphicon-pencil icon edit-action active"
+                        })
+                    );
+                } else {
+                    editAction = _react2.default.createElement("div", null);
+                }
+
                 var _style = this.inlineStyle(validationError, isMissing);
                 if (!view) {
                     return _react2.default.createElement(
                         "div",
-                        { style: _style },
-                        text
+                        {
+                            style: _style,
+                            onMouseEnter: function onMouseEnter() {
+                                return _this2.handleMouseEnter();
+                            },
+                            onMouseLeave: function onMouseLeave() {
+                                return _this2.handleMouseLeave();
+                            }
+                        },
+                        text,
+                        editAction
                     );
                 } else {
                     return _react2.default.createElement(

--- a/packages/react-dynamic-forms/lib/js/formGroup.js
+++ b/packages/react-dynamic-forms/lib/js/formGroup.js
@@ -4,6 +4,8 @@ Object.defineProperty(exports, "__esModule", {
     value: true
 });
 
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 exports.default = formGroup;
@@ -19,6 +21,14 @@ var _flexboxReact2 = _interopRequireDefault(_flexboxReact);
 var _classnames = require("classnames");
 
 var _classnames2 = _interopRequireDefault(_classnames);
+
+var _immutable = require("immutable");
+
+var _immutable2 = _interopRequireDefault(_immutable);
+
+var _underscore = require("underscore");
+
+var _underscore2 = _interopRequireDefault(_underscore);
 
 var _constants = require("../js/constants");
 
@@ -66,7 +76,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
  * users code.
  */
 
-function formGroup(Widget, hideEdit) {
+function formGroup(Control, hideEdit) {
     return function (_React$Component) {
         _inherits(Group, _React$Component);
 
@@ -105,8 +115,7 @@ function formGroup(Widget, hideEdit) {
                     _props$hidden = _props.hidden,
                     hidden = _props$hidden === undefined ? false : _props$hidden,
                     width = _props.width,
-                    allowEdit = _props.allowEdit,
-                    props = _objectWithoutProperties(_props, ["hidden", "width", "allowEdit"]);
+                    props = _objectWithoutProperties(_props, ["hidden", "width"]);
 
                 var name = props.name,
                     label = props.label,
@@ -115,8 +124,13 @@ function formGroup(Widget, hideEdit) {
                     disabled = props.disabled,
                     required = props.required,
                     showRequired = props.showRequired,
-                    onSelectItem = props.onSelectItem;
+                    onSelectItem = props.onSelectItem,
+                    value = props.value,
+                    initialValue = props.initialValue;
 
+
+                var isBeingEdited = edit;
+                var hasChanged = _underscore2.default.isNull(initialValue) ? false : !_immutable2.default.is(value, initialValue);
 
                 var selectStyle = {};
 
@@ -128,18 +142,18 @@ function formGroup(Widget, hideEdit) {
                 }
 
                 //
-                // Widget
+                // Control
                 //
 
-                var widgetWidth = width ? width + "px" : "100%";
-                var widget = _react2.default.createElement(
+                var controlWidth = width ? width + "px" : "100%";
+                var control = _react2.default.createElement(
                     "div",
                     {
                         style: {
-                            width: widgetWidth
+                            width: controlWidth
                         }
                     },
-                    _react2.default.createElement(Widget, props)
+                    _react2.default.createElement(Control, _extends({}, props, { onEditItem: onSelectItem }))
                 );
 
                 //
@@ -167,6 +181,14 @@ function formGroup(Widget, hideEdit) {
                 if (this.props.layout === _constants.FormGroupLayout.COLUMN) {
                     marginLeft = null;
                 }
+
+                var labelColor = "inherit";
+                if (this.state.error) {
+                    labelColor = "b94a48";
+                } else if (hasChanged) {
+                    labelColor = "steelblue";
+                }
+
                 var fieldLabel = _react2.default.createElement(
                     "div",
                     {
@@ -175,7 +197,7 @@ function formGroup(Widget, hideEdit) {
                             whiteSpace: "nowrap",
                             marginLeft: marginLeft,
                             paddingTop: 3,
-                            color: this.state.error ? "b94a48" : "inherit"
+                            color: labelColor
                         }
                     },
                     _react2.default.createElement(
@@ -186,57 +208,77 @@ function formGroup(Widget, hideEdit) {
                 );
                 var labelWidth = this.props.labelWidth ? this.props.labelWidth + "px" : "300px";
 
-                //
-                // Edit
-                //
-
-                var isBeingEdited = edit;
-
-                var flip = {
-                    transform: "scaleX(-1)",
-                    fontSize: 11
-                };
-
-                var editIcon = _react2.default.createElement("span", null);
-                if (this.state.over && allowEdit && !hideEdit) {
-                    editIcon = _react2.default.createElement("i", {
-                        style: flip,
-                        className: isBeingEdited ? "glyphicon glyphicon-pencil icon edit-action active" : "glyphicon glyphicon-pencil icon edit-action",
-                        onClick: function onClick() {
-                            return onSelectItem ? onSelectItem(name) : null;
-                        }
-                    });
-                }
-
                 // Group
-                if (this.props.layout === _constants.FormGroupLayout.INLINE) {
-                    return _react2.default.createElement(
-                        _flexboxReact2.default,
-                        {
-                            flexDirection: "column",
-                            width: widgetWidth,
-                            onMouseEnter: function onMouseEnter() {
-                                return _this2.handleMouseEnter();
+                switch (this.props.layout) {
+                    case _constants.FormGroupLayout.INLINE:
+                        return _react2.default.createElement(
+                            _flexboxReact2.default,
+                            {
+                                flexDirection: "column",
+                                width: controlWidth,
+                                onMouseEnter: function onMouseEnter() {
+                                    return _this2.handleMouseEnter();
+                                },
+                                onMouseLeave: function onMouseLeave() {
+                                    return _this2.handleMouseLeave();
+                                }
                             },
-                            onMouseLeave: function onMouseLeave() {
-                                return _this2.handleMouseLeave();
-                            }
-                        },
-                        widget
-                    );
-                } else if (this.props.layout === _constants.FormGroupLayout.COLUMN) {
-                    return _react2.default.createElement(
-                        _flexboxReact2.default,
-                        {
-                            flexDirection: "column",
-                            onMouseEnter: function onMouseEnter() {
-                                return _this2.handleMouseEnter();
+                            control
+                        );
+                    case _constants.FormGroupLayout.COLUMN:
+                        return _react2.default.createElement(
+                            _flexboxReact2.default,
+                            {
+                                flexDirection: "column",
+                                onMouseEnter: function onMouseEnter() {
+                                    return _this2.handleMouseEnter();
+                                },
+                                onMouseLeave: function onMouseLeave() {
+                                    return _this2.handleMouseLeave();
+                                }
                             },
-                            onMouseLeave: function onMouseLeave() {
-                                return _this2.handleMouseLeave();
-                            }
-                        },
-                        _react2.default.createElement(
+                            _react2.default.createElement(
+                                _flexboxReact2.default,
+                                {
+                                    flexDirection: "row",
+                                    onMouseEnter: function onMouseEnter() {
+                                        return _this2.handleMouseEnter();
+                                    },
+                                    onMouseLeave: function onMouseLeave() {
+                                        return _this2.handleMouseLeave();
+                                    }
+                                },
+                                _react2.default.createElement(
+                                    _flexboxReact2.default,
+                                    null,
+                                    fieldLabel
+                                ),
+                                _react2.default.createElement(
+                                    _flexboxReact2.default,
+                                    { minWidth: "14px", width: "14px" },
+                                    requiredMarker
+                                )
+                            ),
+                            _react2.default.createElement(
+                                _flexboxReact2.default,
+                                {
+                                    flexDirection: "row",
+                                    onMouseEnter: function onMouseEnter() {
+                                        return _this2.handleMouseEnter();
+                                    },
+                                    onMouseLeave: function onMouseLeave() {
+                                        return _this2.handleMouseLeave();
+                                    }
+                                },
+                                _react2.default.createElement(
+                                    _flexboxReact2.default,
+                                    { flexGrow: 1, style: selectStyle },
+                                    control
+                                )
+                            )
+                        );
+                    case _constants.FormGroupLayout.ROW:
+                        return _react2.default.createElement(
                             _flexboxReact2.default,
                             {
                                 flexDirection: "row",
@@ -249,7 +291,7 @@ function formGroup(Widget, hideEdit) {
                             },
                             _react2.default.createElement(
                                 _flexboxReact2.default,
-                                null,
+                                { minWidth: labelWidth, width: labelWidth },
                                 fieldLabel
                             ),
                             _react2.default.createElement(
@@ -259,68 +301,19 @@ function formGroup(Widget, hideEdit) {
                             ),
                             _react2.default.createElement(
                                 _flexboxReact2.default,
-                                { minWidth: "18px", width: "18px", style: selectStyle },
-                                editIcon
-                            )
-                        ),
-                        _react2.default.createElement(
-                            _flexboxReact2.default,
-                            {
-                                flexDirection: "row",
-                                onMouseEnter: function onMouseEnter() {
-                                    return _this2.handleMouseEnter();
+                                {
+                                    width: controlWidth,
+                                    style: selectStyle,
+                                    onDoubleClick: function onDoubleClick() {
+                                        return onSelectItem && !isBeingEdited ? onSelectItem(name) : null;
+                                    }
                                 },
-                                onMouseLeave: function onMouseLeave() {
-                                    return _this2.handleMouseLeave();
-                                }
-                            },
-                            _react2.default.createElement(
-                                _flexboxReact2.default,
-                                { flexGrow: 1, style: selectStyle },
-                                widget
-                            )
-                        )
-                    );
-                } else {
-                    return _react2.default.createElement(
-                        _flexboxReact2.default,
-                        {
-                            flexDirection: "row",
-                            onMouseEnter: function onMouseEnter() {
-                                return _this2.handleMouseEnter();
-                            },
-                            onMouseLeave: function onMouseLeave() {
-                                return _this2.handleMouseLeave();
-                            }
-                        },
-                        _react2.default.createElement(
-                            _flexboxReact2.default,
-                            { minWidth: labelWidth, width: labelWidth },
-                            fieldLabel
-                        ),
-                        _react2.default.createElement(
-                            _flexboxReact2.default,
-                            { minWidth: "14px", width: "14px" },
-                            requiredMarker
-                        ),
-                        _react2.default.createElement(
-                            _flexboxReact2.default,
-                            { minWidth: "18px", width: "18px", style: selectStyle },
-                            editIcon
-                        ),
-                        _react2.default.createElement(
-                            _flexboxReact2.default,
-                            {
-                                width: widgetWidth,
-                                style: selectStyle,
-                                onDoubleClick: function onDoubleClick() {
-                                    return onSelectItem && !isBeingEdited ? onSelectItem(name) : null;
-                                }
-                            },
-                            widget
-                        ),
-                        _react2.default.createElement(_flexboxReact2.default, { flexGrow: 1 })
-                    );
+                                control
+                            ),
+                            _react2.default.createElement(_flexboxReact2.default, { flexGrow: 1 })
+                        );
+                    default:
+                        return _react2.default.createElement("div", null);
                 }
             }
         }]);

--- a/packages/react-dynamic-forms/lib/js/formList.js
+++ b/packages/react-dynamic-forms/lib/js/formList.js
@@ -69,6 +69,14 @@ function list(ItemComponent, hideEditRemove) {
                     this.setState({ selected: null });
                 }
             }
+        }, {
+            key: "handleRevertItem",
+            value: function handleRevertItem(i) {
+                var newValue = this.props.value.set(i, this.props.initialValue.get(i));
+                if (this.props.onChange) {
+                    this.props.onChange(this.props.name, newValue);
+                }
+            }
 
             //Handle an item at i changing to a new value.
 
@@ -192,13 +200,13 @@ function list(ItemComponent, hideEditRemove) {
                 });
                 return total;
             }
-        }, {
-            key: "componentWillReceiveProps",
-            value: function componentWillReceiveProps(nextProps) {
-                if (nextProps.edit === false) {
-                    this.setState({ selected: null });
-                }
-            }
+
+            // componentWillReceiveProps(nextProps) {
+            //     if (nextProps.edit === false) {
+            //         this.setState({ selected: null });
+            //     }
+            // }
+
         }, {
             key: "render",
             value: function render() {
@@ -209,10 +217,11 @@ function list(ItemComponent, hideEditRemove) {
                     var _item$key = item.key,
                         key = _item$key === undefined ? index : _item$key;
 
+                    var itemInitialValue = _this2.props.initialValue ? _this2.props.initialValue.get(index) : null;
+
                     var props = {
                         key: key,
                         name: index,
-                        edit: _this2.props.edit,
                         innerForm: true,
                         hideMinus: hideEditRemove && index < _this2.props.value.size - 1,
                         types: _this2.props.types,
@@ -230,8 +239,9 @@ function list(ItemComponent, hideEditRemove) {
                     };
                     itemComponents.push(_react2.default.createElement(ItemComponent, _extends({}, props, {
                         value: item,
+                        initialValue: itemInitialValue,
                         editable: _this2.props.edit,
-                        edit: _this2.state.selected === index && _this2.props.edit
+                        edit: _this2.state.selected === index
                     })));
                 });
 
@@ -252,9 +262,11 @@ function list(ItemComponent, hideEditRemove) {
 
                 return _react2.default.createElement(_List2.default, {
                     items: itemComponents,
-                    canAddItems: canAddItems && this.props.edit,
-                    canRemoveItems: canRemoveItems && this.props.edit,
-                    canEditItems: this.props.edit,
+                    header: ItemComponent.header,
+                    buttonIndent: ItemComponent.actionButtonIndex,
+                    canAddItems: canAddItems,
+                    canRemoveItems: canRemoveItems,
+                    canEditItems: true,
                     hideEditRemove: hideEditRemove,
                     plusWidth: 400,
                     plusElement: plusElement,
@@ -266,6 +278,9 @@ function list(ItemComponent, hideEditRemove) {
                     },
                     onSelectItem: function onSelectItem(index) {
                         return _this2.handleSelectItem(index);
+                    },
+                    onRevertItem: function onRevertItem(index) {
+                        return _this2.handleRevertItem(index);
                     }
                 });
             }

--- a/packages/react-dynamic-forms/package.json
+++ b/packages/react-dynamic-forms/package.json
@@ -2,36 +2,26 @@
     "name": "react-dynamic-forms",
     "version": "1.0.1",
     "description": "Dynamic forms library for React",
-    "keywords": [
-        "forms",
-        "dynamic",
-        "react"
-    ],
+    "keywords": ["forms", "dynamic", "react"],
     "main": "lib/index.js",
     "author": "ESnet SEG <seg@es.net>",
     "bugs": {
         "url": "https://github.com/esnet/esnet-react-forms/issues"
     },
     "scripts": {
-        "docs": "echo \"*** Building API docs\n\" && react-docgen src/components -x js -o ../website/src/api/docs.json --pretty",
+        "docs":
+            "echo \"*** Building API docs\n\" && react-docgen src/components -x js -o ../website/src/api/docs.json --pretty",
         "lint": "eslint src/components/*.js",
         "test": "npm run lint",
-        "build": "echo \"*** Building lib\n\" && rm -rf lib/* && babel src/components --optional runtime --stage 0 --out-dir lib/components && mkdir lib/css && cp ./src/css/*.css ./lib/css/ && babel src/js --optional runtime --stage 0 --out-dir lib/js && babel src/index.js --optional runtime --stage 0 --out-file lib/index.js",
-        "start-website": "react-scripts start",
-        "build-website": "echo \"*** Building website\n\" && rm -rf docs && react-scripts build && mv build docs",
+        "build":
+            "echo \"*** Building lib\n\" && rm -rf lib/* && babel src/components --optional runtime --stage 0 --out-dir lib/components && mkdir lib/css && cp ./src/css/*.css ./lib/css/ && babel src/js --optional runtime --stage 0 --out-dir lib/js && babel src/index.js --optional runtime --stage 0 --out-file lib/index.js",
         "precommit": "lint-staged",
         "prettier": "prettier --print-width 100 --tab-width 4 --write \"src/**/*.js\""
     },
     "lint-staged": {
-        "*.js": [
-            "prettier --print-width 100 --tab-width 4 --write",
-            "git add"
-        ]
+        "*.js": ["prettier --print-width 100 --tab-width 4 --write", "git add"]
     },
-    "pre-commit": [
-        "lint",
-        "build"
-    ],
+    "pre-commit": ["lint", "build"],
     "license": "BSD-3-Clause-LBNL",
     "peerDependencies": {
         "react": "^16.2.0",

--- a/packages/react-dynamic-forms/src/components/Form.js
+++ b/packages/react-dynamic-forms/src/components/Form.js
@@ -229,6 +229,7 @@ export default class Form extends React.Component {
                     if (this.props.onErrorCountChange) {
                         this.props.onErrorCountChange(this.props.name, errorCount, errorFields);
                     }
+                    this._pendingErrors = null;
                 }
 
                 // On change callback
@@ -496,7 +497,8 @@ export default class Form extends React.Component {
 }
 
 Form.propTypes = {
-    value: PropTypes.object
+    value: PropTypes.object,
+    initialValue: PropTypes.object
 };
 
 Form.defaultProps = {

--- a/packages/react-dynamic-forms/src/components/Form.js
+++ b/packages/react-dynamic-forms/src/components/Form.js
@@ -56,10 +56,10 @@ function getRulesFromSchema(schema) {
 export default class Form extends React.Component {
     constructor(props) {
         super(props);
-        this.state = { 
-            missingCounts: {}, 
-            errorCounts: {}, 
-            selection: null 
+        this.state = {
+            missingCounts: {},
+            errorCounts: {},
+            selection: null
         };
     }
 
@@ -105,6 +105,7 @@ export default class Form extends React.Component {
             }
 
             if (this.props.edit === FormEditStates.TABLE) {
+                props.allowEdit = false;
                 props.layout = FormGroupLayout.INLINE;
             } else {
                 props.layout = this.props.groupLayout;
@@ -128,19 +129,22 @@ export default class Form extends React.Component {
             props.validation = formRules[fieldName].validation;
         }
 
-        // Field value
+        // Field value (current and initial)
         if (this.props.value.has(fieldName)) {
             props.value = this.props.value.get(fieldName);
+            props.initialValue = this.props.initialValue
+                ? this.props.initialValue.get(fieldName)
+                : null;
         }
 
         // Callbacks
-        props.onSelectItem = (fieldName) => this.handleSelectItem(fieldName);
+        props.onSelectItem = fieldName => this.handleSelectItem(fieldName);
         props.onErrorCountChange = (fieldName, count) =>
             this.handleErrorCountChange(fieldName, count);
         props.onMissingCountChange = (fieldName, count) =>
             this.handleMissingCountChange(fieldName, count);
         props.onChange = (fieldName, d) => this.handleChange(fieldName, d);
-        props.onBlur = (fieldName) => this.handleBlur(fieldName);
+        props.onBlur = fieldName => this.handleBlur(fieldName);
 
         return props;
     }
@@ -344,8 +348,10 @@ export default class Form extends React.Component {
                 let makeHidden;
                 const tags = field.tags || [];
                 if (_.isArray(this.props.visible)) {
-                    makeHidden = !(_.intersection(tags, this.props.visible).length > 0 ||
-                        _.contains(tags, "all"));
+                    makeHidden = !(
+                        _.intersection(tags, this.props.visible).length > 0 ||
+                        _.contains(tags, "all")
+                    );
                 } else {
                     makeHidden = !(_.contains(tags, this.props.visible) || _.contains(tags, "all"));
                 }
@@ -405,7 +411,8 @@ export default class Form extends React.Component {
      * the whole form render.
      */
     shouldComponentUpdate(nextProps, nextState) {
-        const update = nextProps.value !== this.props.value ||
+        const update =
+            nextProps.value !== this.props.value ||
             nextProps.edit !== this.props.edit ||
             nextProps.schema !== this.props.schema ||
             nextProps.visibility !== this.props.visibility ||

--- a/packages/react-dynamic-forms/src/components/List.js
+++ b/packages/react-dynamic-forms/src/components/List.js
@@ -35,6 +35,20 @@ import "../css/icon.css";
  *                       possible items that can be added from a list).
  */
 export default class List extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            hover: false
+        };
+    }
+    handleMouseEnter() {
+        this.setState({ hover: true });
+    }
+
+    handleMouseLeave() {
+        this.setState({ hover: false });
+    }
+
     addItem() {
         if (this.props.onAddItem) {
             this.props.onAddItem();
@@ -53,6 +67,13 @@ export default class List extends React.Component {
         }
     }
 
+    revertItem(index) {
+        if (this.props.onRevertItem) {
+            this.props.onRevertItem(index);
+            this.selectItem(null);
+        }
+    }
+
     handleDeselect() {
         this.selectItem(null);
     }
@@ -62,10 +83,12 @@ export default class List extends React.Component {
         const addMinus = this.props.canRemoveItems;
         const addEdit = this.props.canEditItems;
 
+        const mouseOver = this.state.hover;
+
         // Plus [+] icon
-        let plus;
-        if (addPlus) {
-            plus = (
+        let plusIcon;
+        if (addPlus && mouseOver) {
+            plusIcon = (
                 <i
                     key="plus"
                     className="glyphicon glyphicon-plus icon add-action"
@@ -73,8 +96,11 @@ export default class List extends React.Component {
                 />
             );
         } else {
-            plus = <div />;
+            plusIcon = <div />;
         }
+
+        const LISTWIDTH = 600;
+        const ICONWIDTH = 28;
 
         // Build the item list, which is a list of table rows, each row containing
         // an item and a [-] icon used for removing that item.
@@ -100,13 +126,12 @@ export default class List extends React.Component {
                 isEditable = true;
             }
             if (isEditable) {
-                if (addMinus && !itemMinusHide) {
+                if (addMinus && !itemMinusHide && mouseOver) {
                     minus = (
                         <i
                             id={index}
                             key={minusActionKey}
                             className="glyphicon glyphicon-remove hostile_icon delete-action"
-                            onClick={() => this.removeItem(index)}
                         />
                     );
                 } else {
@@ -114,53 +139,41 @@ export default class List extends React.Component {
                     minus = <div className="icon delete-action" />;
                 }
 
-                const flip = {
-                    transform: "scaleX(-1)",
-                    fontSize: 10
-                };
-
                 // Edit item icon
-                if (addEdit) {
-                    if (isBeingEdited) {
-                        edit = (
-                            <i
-                                id={index}
-                                key={minusActionKey}
-                                className="glyphicon glyphicon-chevron-down icon edit-action active"
-                                onClick={() => this.selectItem(index)}
-                            />
-                        );
-                    } else {
-                        edit = (
-                            <i
-                                id={index}
-                                key={minusActionKey}
-                                style={flip}
-                                className="glyphicon glyphicon-chevron-left icon edit-action"
-                                onClick={() => this.selectItem(index)}
-                            />
-                        );
-                    }
+                if (addEdit && mouseOver) {
+                    edit = (
+                        <i
+                            id={index}
+                            key={minusActionKey}
+                            style={{ paddingLeft: 5, paddingRight: 5 }}
+                            className="glyphicon glyphicon-pencil icon edit-action active"
+                        />
+                    );
                 }
             }
 
             const minusAction = addMinus ? (
-                <Flexbox width="28px">
-                    <span key={actionSpanKey} className="icon" style={{ background: "white" }}>
+                <Flexbox width="28px" onClick={() => this.removeItem(index)}>
+                    <span
+                        key={actionSpanKey}
+                        className="icon"
+                        style={{ paddingLeft: 5, paddingRight: 5 }}
+                    >
                         {minus}
                     </span>
                 </Flexbox>
             ) : (
-                <div />
+                <div style={{ height: 30 }} />
             );
 
             const editAction = addEdit ? (
-                <Flexbox width="28px">
-                    <span
-                        key={actionSpanKey}
-                        className="icon"
-                        style={{ background: "white", verticalAlign: "top" }}
-                    >
+                <Flexbox
+                    width="28px"
+                    onClick={() => {
+                        this.selectItem(index);
+                    }}
+                >
+                    <span key={actionSpanKey} className="icon" style={{ verticalAlign: "top" }}>
                         {edit}
                     </span>
                 </Flexbox>
@@ -168,33 +181,102 @@ export default class List extends React.Component {
                 <div />
             );
 
+            const doneStyle = {
+                padding: 5,
+                marginRight: 5,
+                marginBottom: 5,
+                borderStyle: "solid",
+                borderWidth: 1,
+                borderColor: "#b5b5b5",
+                borderRadius: 2,
+                color: "steelblue",
+                cursor: "pointer"
+            };
+
+            const cancelStyle = {
+                padding: 5,
+                marginRight: 5,
+                marginBottom: 5,
+                borderStyle: "solid",
+                borderWidth: 1,
+                borderColor: "#b5b5b5",
+                borderRadius: 2,
+                color: "#AAA",
+                cursor: "pointer"
+            };
+
             // JSX for each row, includes: UI Item and [x] remove item button
-            return (
-                <li
-                    height="80px"
-                    key={itemKey}
-                    className="esnet-forms-list-item"
-                    style={{
-                        borderBottomStyle: "solid",
-                        borderBottomColor: "#DDD",
-                        borderBottomWidth: 1
-                    }}
-                >
-                    <Flexbox flexDirection="row">
-                        {minusAction}
-                        {editAction}
-                        <Flexbox flexGrow={1}>
-                            <span key={itemSpanKey} className={listEditItemClass}>
-                                {item}
-                            </span>
+
+            if (!isBeingEdited) {
+                return (
+                    <li
+                        height="80px"
+                        width="600px"
+                        key={itemKey}
+                        className="esnet-forms-list-item"
+                        style={{
+                            borderBottomStyle: "solid",
+                            borderBottomColor: "#DDD",
+                            borderBottomWidth: 1
+                        }}
+                    >
+                        <Flexbox flexDirection="row" style={{ width: "100%", paddingTop: 5 }}>
+                            <Flexbox style={{ width: LISTWIDTH - ICONWIDTH * 2 }}>
+                                <span key={itemSpanKey} className={listEditItemClass}>
+                                    {item}
+                                </span>
+                            </Flexbox>
+                            {minusAction}
+                            {editAction}
                         </Flexbox>
-                    </Flexbox>
-                </li>
-            );
+                    </li>
+                );
+            } else {
+                return (
+                    <li
+                        height="80px"
+                        key={itemKey}
+                        className="esnet-forms-list-item"
+                        style={{
+                            borderBottomStyle: "solid",
+                            borderBottomColor: "#DDD",
+                            borderBottomWidth: 1
+                        }}
+                    >
+                        <Flexbox
+                            flexDirection="row"
+                            style={{ width: "100%", paddingTop: 10, paddingBottom: 10 }}
+                        >
+                            <Flexbox flexDirection="column">
+                                <Flexbox style={{ width: LISTWIDTH - ICONWIDTH * 2 }}>
+                                    <span key={itemSpanKey} className={listEditItemClass}>
+                                        {item}
+                                    </span>
+                                </Flexbox>
+                                <Flexbox
+                                    style={{ fontSize: 12, marginLeft: this.props.buttonIndent }}
+                                >
+                                    <span style={doneStyle} onClick={() => this.handleDeselect()}>
+                                        DONE
+                                    </span>
+                                    <span
+                                        style={cancelStyle}
+                                        onClick={() => this.revertItem(index)}
+                                    >
+                                        REVERT
+                                    </span>
+                                </Flexbox>
+                            </Flexbox>
+                            {minusAction}
+                        </Flexbox>
+                    </li>
+                );
+            }
         });
 
         // Build the [+] elements
-        if (addPlus) {
+        let plus;
+        if (addPlus && mouseOver) {
             if (this.props.plusElement) {
                 plus = this.props.plusElement;
             } else {
@@ -204,9 +286,9 @@ export default class List extends React.Component {
                             <span
                                 key="plus"
                                 className="icon"
-                                style={{ background: "white", verticalAlign: "top", fontSize: 10 }}
+                                style={{ verticalAlign: "top", fontSize: 10 }}
                             >
-                                {plus}
+                                {plusIcon}
                             </span>
                         </Flexbox>
                         <Flexbox width="28px" />
@@ -214,8 +296,40 @@ export default class List extends React.Component {
                 );
             }
         } else {
-            plus = <div />;
+            plus = <div style={{ height: 35 }} />;
         }
+
+        //
+        // Build the header
+        //
+
+        const headerStyle = {
+            fontSize: 11,
+            paddingTop: 3,
+            height: 20,
+            color: "#9a9a9a",
+            borderBottom: "#ddd",
+            borderBottomStyle: "solid",
+            borderBottomWidth: 1
+        };
+
+        const headerItems = _.map(this.props.header, (size, label) => {
+            return (
+                <Flexbox width={`${size}px`}>
+                    <span style={{ verticalAlign: "top", fontSize: 10, paddingLeft: 3 }}>
+                        {label}
+                    </span>
+                </Flexbox>
+            );
+        });
+
+        const header = this.props.header ? (
+            <Flexbox flexDirection="row" style={headerStyle}>
+                {headerItems}
+            </Flexbox>
+        ) : (
+            <div />
+        );
 
         //
         // Build the table of item rows, with the [+] at the bottom if required
@@ -224,11 +338,15 @@ export default class List extends React.Component {
         return (
             <div
                 style={{
+                    width: 600,
                     borderTopStyle: "solid",
                     borderTopWidth: 1,
                     borderTopColor: "#DDD"
                 }}
+                onMouseEnter={() => this.handleMouseEnter()}
+                onMouseLeave={() => this.handleMouseLeave()}
             >
+                {header}
                 <ul className="esnet-forms-listeditview-container">
                     <ReactCSSTransitionGroup
                         transitionName="esnet-forms-list-item"

--- a/packages/react-dynamic-forms/src/components/TextEdit.js
+++ b/packages/react-dynamic-forms/src/components/TextEdit.js
@@ -24,9 +24,22 @@ import "../css/textedit.css";
 class TextEdit extends React.Component {
     constructor(props) {
         super(props);
-        this.state = { 
-            touched: false 
+        this.state = {
+            hover: false,
+            touched: false
         };
+    }
+
+    handleMouseEnter() {
+        this.setState({ hover: true });
+    }
+
+    handleMouseLeave() {
+        this.setState({ hover: false });
+    }
+
+    handleEditItem() {
+        this.props.onEditItem(this.props.name);
     }
 
     isEmpty(value) {
@@ -161,6 +174,10 @@ class TextEdit extends React.Component {
         const isMissing = this.isMissing(this.props.value);
         const { validationError, validationErrorMessage } = this.getError(this.props.value);
 
+        const iconStyle = {
+            fontSize: 11
+        };
+
         if (this.props.edit) {
             // Error style/message
             let className = "";
@@ -179,7 +196,9 @@ class TextEdit extends React.Component {
             return (
                 <div className={className}>
                     <input
-                        ref={(input) => { this.textInput = input; }}
+                        ref={input => {
+                            this.textInput = input;
+                        }}
                         className="form-control input-sm"
                         style={style}
                         type={type}
@@ -194,13 +213,37 @@ class TextEdit extends React.Component {
             );
         } else {
             const view = this.props.view;
-            let text = this.props.value;
+            let text = <span>{this.props.value}</span>;
             if (isMissing) {
-                text = " ";
+                text = <span />;
             }
+
+            let editAction = <span />;
+            if (this.state.hover && this.props.allowEdit) {
+                editAction = (
+                    <span style={{ marginLeft: 5 }} onClick={() => this.handleEditItem()}>
+                        <i
+                            style={iconStyle}
+                            className="glyphicon glyphicon-pencil icon edit-action active"
+                        />
+                    </span>
+                );
+            } else {
+                editAction = <div />;
+            }
+
             const style = this.inlineStyle(validationError, isMissing);
             if (!view) {
-                return <div style={style}>{text}</div>;
+                return (
+                    <div
+                        style={style}
+                        onMouseEnter={() => this.handleMouseEnter()}
+                        onMouseLeave={() => this.handleMouseLeave()}
+                    >
+                        {text}
+                        {editAction}
+                    </div>
+                );
             } else {
                 return <div style={style}>{view(text)}</div>;
             }

--- a/packages/react-dynamic-forms/src/js/formList.js
+++ b/packages/react-dynamic-forms/src/js/formList.js
@@ -34,6 +34,13 @@ export default function list(ItemComponent, hideEditRemove) {
             }
         }
 
+        handleRevertItem(i) {
+            let newValue = this.props.value.set(i, this.props.initialValue.get(i));
+            if (this.props.onChange) {
+                this.props.onChange(this.props.name, newValue);
+            }
+        }
+
         //Handle an item at i changing to a new value.
         handleChangeItem(i, value) {
             let newValue = this.props.value.set(i, value);
@@ -136,20 +143,23 @@ export default function list(ItemComponent, hideEditRemove) {
             return total;
         }
 
-        componentWillReceiveProps(nextProps) {
-            if (nextProps.edit === false) {
-                this.setState({ selected: null });
-            }
-        }
+        // componentWillReceiveProps(nextProps) {
+        //     if (nextProps.edit === false) {
+        //         this.setState({ selected: null });
+        //     }
+        // }
 
         render() {
             const itemComponents = [];
             this.props.value.forEach((item, index) => {
                 const { key = index } = item;
+                const itemInitialValue = this.props.initialValue
+                    ? this.props.initialValue.get(index)
+                    : null;
+
                 const props = {
                     key,
                     name: index,
-                    edit: this.props.edit,
                     innerForm: true,
                     hideMinus: hideEditRemove && index < this.props.value.size - 1,
                     types: this.props.types,
@@ -167,8 +177,9 @@ export default function list(ItemComponent, hideEditRemove) {
                     <ItemComponent
                         {...props}
                         value={item}
+                        initialValue={itemInitialValue}
                         editable={this.props.edit}
-                        edit={this.state.selected === index && this.props.edit}
+                        edit={this.state.selected === index}
                     />
                 );
             });
@@ -186,15 +197,18 @@ export default function list(ItemComponent, hideEditRemove) {
             return (
                 <List
                     items={itemComponents}
-                    canAddItems={canAddItems && this.props.edit}
-                    canRemoveItems={canRemoveItems && this.props.edit}
-                    canEditItems={this.props.edit}
+                    header={ItemComponent.header}
+                    buttonIndent={ItemComponent.actionButtonIndex}
+                    canAddItems={canAddItems}
+                    canRemoveItems={canRemoveItems}
+                    canEditItems={true}
                     hideEditRemove={hideEditRemove}
                     plusWidth={400}
                     plusElement={plusElement}
                     onAddItem={() => this.handleAddItem()}
                     onRemoveItem={index => this.handleRemovedItem(index)}
                     onSelectItem={index => this.handleSelectItem(index)}
+                    onRevertItem={index => this.handleRevertItem(index)}
                 />
             );
         }

--- a/packages/website/src/examples/form/form_docs.md
+++ b/packages/website/src/examples/form/form_docs.md
@@ -1,83 +1,164 @@
 ### Forms example
 
-The forms library is designed to help you build a complete form. In this example
-we create a simple contacts form. There are other examples too of forms which change
-their structure as the user interacts with tham, as well as demostrating the use
-of lists within the forms. But here we keep it relatively simple.
+The forms library is designed to help you build a complete form, rather than use the individual controls by themselves. In this example we create a simple contacts form.
 
-**What do we want from our form?**
+See other examples for forms which change their structure as the user interacts with them, as well as demonstrating the use of lists within the forms. But here we keep it relatively simple.
 
-Essentially we want to provide perhaps some initial data, our form `"value"`, 
-defaults in the case of a new form, or maybe our current
-database state in the case of editing an existing entity.
+#### Form requirements
+
+Let's first look at what we need for our form.
+
+To begin with we want to provide some initial data, our form `"value"` which may be defaults in the case of a new form, or our current database state in the case of editing an existing entity.
 
 As the user edits the data, we'll want to track that. We may choose to save
 it on submit (if it's a new form, that's likely), or save it as the user edits it
-(perhaps if they are using inline editing we might
-want to save the data when any fields are changed). Either way, the forms library
-allows you to provide a callback function, which will be called whenever the values
-in the form change. How you want to respond to that is up to you, but this example
-demostrates one possible approach.
+(perhaps if they are using inline editing we might want to save the data when any fields are changed). This depends on your requirements. Either way, the forms library allows you to provide a callback function, which will be called whenever the values in the form change. How you want to respond to that is up to you, but this example demonstrates one possible approach.
 
 In addition to knowing that the form values have changed, we also need to know if
 the form has any errors or missing fields. We do this via callbacks as well, where
-each callback will tell you the number of missing or empty fields that exist within
-the form. You can use that to control if the user can submit the form or not, as
-we do in this example.
+each callback will tell you the number of missing or empty fields that exist within the form. You can use that to control if the user can submit the form or not, as we do in this example.
 
-Okay, so we have initial values and we have some callbacks.
+Okay, so we have initial values and we have some callbacks. Now to build a form.
 
-**How do we get a form up and running to use those?**
+#### Building the form
 
-Forms have two concerns. Each form has a schema which we use to provide the meta
-data for fields within the form. This includes UI elements like the label for each
-fields, the placeholder text, etc, but also rules around the field itself. For
-example a field (called an Field in this library),
+Forms have two concerns. Each form has a `Schema` which we use to provide the meta
+data for fields within the form. This includes UI elements like the `label` for each fields, the `placeholder` text, etc, but also validation rules around the field itself.
 
-The form elements are defined by a **schema**. Schemas can be defined with JSX or manually. Here's the schema used in this page:
+Schemas can be defined with JSX or manually. Here's the schema used in this page:
 
-    const schema = (
-        <Schema>
-            <Field name="first_name" label="First name" placeholder="Enter first name"
-                    required={true} validation={{"type": "string"}}/>
-            <Field name="last_name" label="Last name" placeholder="Enter last name"
-                    required={true} validation={{"type": "string"}}/>
-            <Field name="email" label="Email" placeholder="Enter valid email address"
-                    validation={{"format": "email"}}/>
-            <Field name="birthdate" label="Birthdate"  required={true} />
+```js
+const schema = (
+    <Schema>
+        <Field name="first_name" label="First name" placeholder="Enter first name"
+                required={true} validation={{"type": "string"}}/>
+        <Field name="last_name" label="Last name" placeholder="Enter last name"
+                required={true} validation={{"type": "string"}}/>
+        <Field name="email" label="Email" placeholder="Enter valid email address"
+                validation={{"format": "email"}}/>
+        <Field name="birthdate" label="Birthdate"  required={true} />
 
-        </Schema>
-    );
+    </Schema>
+);
+```
 
-As you can see the schema is used to associate the Field name (`"first_name"` for example) with some properties which define how it looks and what is a valid value for that Field. Here we define a label (`"First name"`), a placeholder text, and some validation properties. Required can be set true to have the form track that this Field field needs to be filled out before the form is submitted. More on errors and missing value counts below. In addition to being required or not, the Field can have a validation prop set which will be passed to Revalidator for field validation while the user interacts with the form. It is most common to use it to specify the type (`"string", "integer", or "number"`), but you can also specify a format, such as in the example above where the email Field is checked to make sure it is a valid email address. Maximum string lengths, or ranges of numeric values can also be specified. For full details see the [Revalidator website](https://github.com/flatiron/revalidator).
+As you can see the schema is used to associate the `Field` `name` (`"first_name"` for example) with some properties which define how it looks and what is a valid value for that Field.
 
-Rendering is not automatic. Instead the form itself is a React component that you define. We define the form itself like this:
+Here, for each field, we define:
+ * a `label` text
+ * a `placeholder` text
+ * a `validation` properties
+ * a `required` flag
+ 
+ Some quick notes on these: firstly, `required` can be set `true` to have the form track that this field needs to be filled out before the form is submitted (More on errors and missing value counts below.) Secondly, in addition to being required or not, the `Field` can have a `validation` prop set which will be passed to the Revalidator library for field validation while the user interacts with the form. It is most common to use it to specify the type ("string", "integer", or "number"), but you can also specify a format, such as in the example above where the `email` field is checked to make sure it is a valid email address. Maximum string lengths, or ranges of numeric values can also be specified. For full details see the [Revalidator website](https://github.com/flatiron/revalidator).
 
+Now that we have a schema we should have a form. Not so much. This library separates the presentation of the form from the schema. This fits in with React as you can use regular React `render()` code to render the form but with the addition that when you render a control you refer to the field name in the schema.
+
+So, the form itself is a regular React component that you define. We define the form itself like this:
+
+```js
     class ContactForm extends React.Component {
-
+        render() {
+            return (
+                ...
+            )
+        }
     }
+```
 
-And then implement the form layout like this:
+And then implement the form `render()` like this:
 
-    renderForm() {
-        const disableSubmit = this.hasErrors();
-        return (
-            <Form>
-                <TextEdit field="first_name" width={300} />
-                <TextEdit field="last_name" width={300} />
-                <TextEdit field="email" width={500} />
-                <DateEdit field="birthdate" />
-                <hr />
-                <input className="btn btn-default" type="submit" value="Submit" disabled={disableSubmit}/>
-            </Form>
-        );
-    }
+```js
+render() {
+    const disableSubmit = this.hasErrors();
+    return (
+            return (
+                <Form
+                    name="basic"
+                    style={style}
+                    schema={schema}
+                    value={this.state.value}
+                    edit={this.state.editMode}
+                    labelWidth={200}
+                    onSubmit={this.handleSubmit}
+                    onChange={(formName, value) => this.handleChange(formName, value)}
+                    onMissingCountChange={(fieldName, missing) =>
+                        this.setState({ hasMissing: missing > 0 })}
+                    onErrorCountChange={(fieldName, errors) =>
+                        this.setState({ hasErrors: errors > 0 })}
+                >
+                    <Chooser
+                        field="type"
+                        width={150}
+                        choiceList={availableTypes}
+                        disableSearch={true}
+                    />
+                    <TextEdit field="first_name" width={300} />
+                    <TextEdit field="last_name" width={300} />
+                    <TextEdit
+                        field="email"
+                        width={400}
+                        view={value => {
+                            return (
+                                <a>
+                                    {value}
+                                </a>
+                            );
+                        }}
+                    />
+                    <DateEdit field="birthdate" width={100} />
+                    <CheckBoxes field="languages" optionList={availableLanguages} />
+                    <RadioButtons field="options" optionList={availableEmailOptions} />
+                    <TagsEdit
+                        field="tags"
+                        tagList={this.state.tagList}
+                        onTagListChange={(name, tagList) => this.setState({ tagList })}
+                        width={400}
+                    />
+                    <TextArea
+                        field="notes"
+                        width={400}
+                        view={value => {
+                            return <Markdown source={value} />;
+                        }}
+                    />
+                    <View
+                        field="city"
+                        width={400}
+                        view={value => {
+                            return (
+                                <b>
+                                    {value}
+                                </b>
+                            );
+                        }}
+                    />
+                    <hr />
+                </Form>
+            );
+    );
+}
+```
 
-As you can see, we return a `<Form>` element which contains further JSX, which is a convenience. In fact, you can define this with a `<form>` too. You can use any JSX in here to render the form however you like. This makes the layout of the form as flexible as any other React code.
+As you can see, we return a `<Form>` element which contains further JSX. You can use any JSX in here to render the form however you like. This makes the layout of the form as flexible as any other React code.
 
-The special elements here are the `TextEdit`s. They specify an `field` prop which references the schema (we'll see how to get the schema hooked up in a minute). Each TextEditGroup will generate a label and a form control (in this case a `TextEdit`). We use Bootstrap for the layout. In addition to TextEditGroups there's also: `TextAreaGroup`, `ChooserGroup`, `OptionsGroup` and `TagsGroup`. You can also wrap your own controls in the generic `Group`.
+Let's walk through the important parts of this example:
 
-Now that we have out form it's time to use it. Typically the form will be contained (rendered by) another React component which will hold the business logic of sourcing the schema and initial values, as well as handling the submit of the form in some way.
+ 1. we provide the `schema` to the `Form` as a prop. This tells the form to expect fields contained in the schema provided.
+
+ 2. we provide the current state of the `Form` by providing the `value` prop. Initially this is the default state or loaded state of the form, but as the user changes the form it will reflect the current state. `value` is an Immutable.JS Map that we typically keep in component state (`this.state.value`) and update via the form callback (`onChange()`).
+
+ 3. we provide the mode the form is in, which can be view only (NEVER), view with inline editing (SELECTED) or a fully editable (ALWAYS)
+
+ 4. we provide the actual controls. Let's look at the `TextEdit`s as an example. They specify an `field` prop which references the schema `Field`'s `name`. Each `TextEdit` will generate a label and a corresponding form control (in this case a single line text edit control). There's a useful set of controls provided with the library which are built mostly on Bootstrap standard controls.
+ 
+ 5. we provide callback for important changes to the form. `onChange()` gives continuous changes to the form. These need to be passed back down into the form (the form is "controlled"). `onMissingCountChange()` and `onErrorCountChange()` gives us notification of how many missing fields and errors are in our form at any given moment. These include errors inside sub forms and lists of forms etc. You can use the states of these to give feedback to the user and block the user from submitting.
+
+ 6. finally we provide an onSubmit callback which tells us the user submitted the form. Given you have the onChange callback you could also save continuously. It depends on the user experience you want.
+
+#### Using the form
+
+Now that we have our `ContactForm` it's time to use it. Typically the form will be contained (rendered by) another React component which will hold the business logic of sourcing the `schema` and providing initial values, as well as handling the submit of the form in some way.
 
 To render the form we created above we need to pass in the initial values and schema. Here is the key part of render function for this page's example:
 

--- a/packages/website/src/examples/list/Index.js
+++ b/packages/website/src/examples/list/Index.js
@@ -36,6 +36,13 @@ This shows an example form with a list of emails that can be added or removed.
 class EmailForm extends React.Component {
     static defaultValues = { email_type: 1, email: "" };
 
+    static header = {
+        Email: 250,
+        Type: 250
+    };
+
+    static actionButtonIndex = 62;
+
     static schema = (
         <Schema>
             <Field
@@ -68,7 +75,8 @@ class EmailForm extends React.Component {
             onChange,
             onMissingCountChange,
             onErrorCountChange,
-            value = EmailForm.defaultValues
+            value = EmailForm.defaultValues,
+            initialValue = EmailForm.defaultValues
         } = this.props;
         const callbacks = { onChange, onMissingCountChange, onErrorCountChange };
 
@@ -78,6 +86,7 @@ class EmailForm extends React.Component {
                     name={this.props.name}
                     schema={EmailForm.schema}
                     value={value}
+                    initialValue={initialValue}
                     edit={FormEditStates.ALWAYS}
                     labelWidth={50}
                     {...callbacks}
@@ -97,6 +106,7 @@ class EmailForm extends React.Component {
                     name={this.props.name}
                     schema={EmailForm.schema}
                     value={value}
+                    intialValue={initialValue}
                     edit={FormEditStates.TABLE}
                     labelWidth={50}
                     {...callbacks}
@@ -221,7 +231,7 @@ class ContactForm extends React.Component {
 
     render() {
         const style = { background: "#FAFAFA", padding: 10, borderRadius: 5 };
-        const { value } = this.props;
+        const { value, initialValue } = this.props;
         const emails = value.get("emails");
 
         return (
@@ -231,6 +241,7 @@ class ContactForm extends React.Component {
                     style={style}
                     schema={this.schema()}
                     value={value}
+                    initialValue={initialValue}
                     edit={this.state.editMode}
                     labelWidth={100}
                     onSubmit={() => this.handleSubmit()}
@@ -254,19 +265,22 @@ class ContactForm extends React.Component {
     }
 }
 
+const savedValues = new Immutable.fromJS({
+    first_name: "Bill",
+    last_name: "Jones",
+    emails: [
+        { email: "b.jones@work.com", email_type: 1 },
+        { email: "bill@gmail.com", email_type: 2 }
+    ]
+});
+
 class list extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
             loaded: false,
-            value: new Immutable.fromJS({
-                first_name: "Bill",
-                last_name: "Jones",
-                emails: [
-                    { email: "b.jones@work.com", email_type: 1 },
-                    { email: "bill@gmail.com", email_type: 2 }
-                ]
-            })
+            value: Immutable.Map(), // value will update as the user interacts with the form
+            initialValue: Immutable.Map() // initialValue will only update when the user saves the form
         };
         this.handleAlertDismiss = this.handleAlertDismiss.bind(this);
         this.handleChange = this.handleChange.bind(this);
@@ -277,8 +291,13 @@ class list extends React.Component {
     componentDidMount() {
         // Simulate ASYNC state update
         setTimeout(() => {
-            this.setState({ loaded: true });
-        }, 0);
+            console.log("Loaded!");
+            this.setState({
+                loaded: true,
+                value: savedValues,
+                initialValue: savedValues
+            });
+        }, 3000);
     }
 
     handleChange(form, value) {
@@ -320,6 +339,7 @@ class list extends React.Component {
             return (
                 <ContactForm
                     value={this.state.value}
+                    initialValue={this.state.initialValue}
                     onChange={this.handleChange}
                     onMissingCountChange={this.handleMissingCountChange}
                     onErrorCountChange={this.handleErrorCountChange}
@@ -327,8 +347,8 @@ class list extends React.Component {
             );
         } else {
             return (
-                <div style={{ marginTop: 50 }}>
-                    <b>Loading...</b>
+                <div style={{ marginTop: 50, marginBottom: 100 }}>
+                    <b>Loading saved data...</b>
                 </div>
             );
         }
@@ -345,8 +365,8 @@ class list extends React.Component {
                 </div>
                 <hr />
                 <div className="row">
-                    <div className="col-md-8">{this.renderContactForm()}</div>
-                    <div className="col-md-4">
+                    <div className="col-md-12">{this.renderContactForm()}</div>
+                    {/* <div className="col-md-4">
                         <b>STATE:</b>
                         <pre style={{ borderLeftColor: "steelblue" }}>
                             value = {JSON.stringify(this.state.value.toJSON(), null, 3)}
@@ -357,7 +377,7 @@ class list extends React.Component {
                         <pre style={{ borderLeftColor: "orange" }}>
                             {`hasMissing: ${this.state.hasMissing}`}
                         </pre>
-                    </div>
+                    </div> */}
                 </div>
                 <div className="row">
                     <div className="col-md-9">{this.renderAlert()}</div>

--- a/packages/website/src/guides/getting_started.md
+++ b/packages/website/src/guides/getting_started.md
@@ -64,7 +64,7 @@ Now onto the form itself...
 
 ## Imports
 
-Open up src/App.js. This is where the code is that made the spinning logo placeholder page.
+Open up **src/App.js**. This is where the code is that made the spinning logo placeholder page.
 
 First we'll replace the imports in there with our own set:
 


### PR DESCRIPTION
 * Overhaul of the editing of lists so that you can directly edit rows of lists without having to click "edit" on the list first.
 * Moves all the edit action icons to the right of view text, but lets the control itself determine where to put them. This way they don't have to be excessively far to the right.
Why move them? Most inline editing has edit actions to the right, so more familiar. It also enables multiple icons without taking up increasing space between the label and the control. This means the list editing can be displayed the same as other inline editing, but display both a row edit icon and a delete row icon together. Plus, we can add a revert icon.
 * Fixes a bug where the cursor would jump to the end of the line
 * When you start and inline edit, the text is selected so you can type over it without an additional click