### PR TITLE
do not copy validation functions with deepcopy

### DIFF
--- a/packages/react-dynamic-forms/lib/components/Form.js
+++ b/packages/react-dynamic-forms/lib/components/Form.js
@@ -82,6 +82,10 @@ function getRulesFromSchema(schema) {
             if (child.type === _Field2.default) {
                 var required = child.props.required || false;
                 var validation = (0, _deepcopy2.default)(child.props.validation);
+                // the conform is a function that can not be copied properly
+                if (child.props.validation && "conform" in child.props.validation) {
+                    validation["conform"] = child.props.validation["conform"];
+                }
                 rules[child.props.name] = { required: required, validation: validation };
             }
         });

--- a/packages/react-dynamic-forms/src/components/Form.js
+++ b/packages/react-dynamic-forms/src/components/Form.js
@@ -46,6 +46,10 @@ function getRulesFromSchema(schema) {
             if (child.type === Field) {
                 const required = child.props.required || false;
                 const validation = deepCopy(child.props.validation);
+                // the conform is a function that can not be copied properly
+                if (child.props.validation && "conform" in child.props.validation) {
+                    validation["conform"] = child.props.validation["conform"];
+                }
                 rules[child.props.name] = { required, validation };
             }
         });

--- a/packages/website/src/examples/list/Index.js
+++ b/packages/website/src/examples/list/Index.js
@@ -130,10 +130,6 @@ class ContactForm extends React.Component {
         };
     }
 
-    validate(name){
-        return true ? name === "Jones" : false;
-    }
-
     schema() {
         return (
             <Schema>
@@ -147,9 +143,9 @@ class ContactForm extends React.Component {
                 <Field
                     name="last_name"
                     label="Last name"
-                    placeholder="Enter last name (allowed: Jones only)"
+                    placeholder="Enter last name"
                     required={true}
-                    validation={{ type: "string", message: "This field can be Jones only", conform: a => this.validate(a)}}
+                    validation={{ type: "string" }}
                 />
                 <Field name="emails" label="Emails" />
             </Schema>

--- a/packages/website/src/examples/list/Index.js
+++ b/packages/website/src/examples/list/Index.js
@@ -129,6 +129,11 @@ class ContactForm extends React.Component {
             hasErrors: false
         };
     }
+
+    validate(name){
+        return true ? name === "Jones" : false;
+    }
+
     schema() {
         return (
             <Schema>
@@ -142,9 +147,9 @@ class ContactForm extends React.Component {
                 <Field
                     name="last_name"
                     label="Last name"
-                    placeholder="Enter last name"
+                    placeholder="Enter last name (allowed: Jones only)"
                     required={true}
-                    validation={{ type: "string" }}
+                    validation={{ type: "string", message: "This field can be Jones only", conform: a => this.validate(a)}}
                 />
                 <Field name="emails" label="Emails" />
             </Schema>

--- a/packages/website/src/examples/list/list_docs.md
+++ b/packages/website/src/examples/list/list_docs.md
@@ -50,10 +50,6 @@ Having defined that, we can now create a form to edit a contact:
 
     class ContactForm extends React.Component {
 
-        validate(name){
-            return true ? name === "Jones" : false;
-        }
-
         schema() {
             return (
                 <Schema>
@@ -69,7 +65,7 @@ Having defined that, we can now create a form to edit a contact:
                         label="Last name"
                         placeholder="Enter last name"
                         required={true}
-                        validation={{ type: "string", message: "This field can be Jones only", conform: a => this.validate(a)}}
+                        validation={{ type: "string" }}
                     />
                     <Field name="emails" label="Emails" />
                 </Schema>

--- a/packages/website/src/examples/list/list_docs.md
+++ b/packages/website/src/examples/list/list_docs.md
@@ -50,6 +50,10 @@ Having defined that, we can now create a form to edit a contact:
 
     class ContactForm extends React.Component {
 
+        validate(name){
+            return true ? name === "Jones" : false;
+        }
+
         schema() {
             return (
                 <Schema>
@@ -65,7 +69,7 @@ Having defined that, we can now create a form to edit a contact:
                         label="Last name"
                         placeholder="Enter last name"
                         required={true}
-                        validation={{ type: "string" }}
+                        validation={{ type: "string", message: "This field can be Jones only", conform: a => this.validate(a)}}
                     />
                     <Field name="emails" label="Emails" />
                 </Schema>


### PR DESCRIPTION
In ESDB, we are giving functions to `conform` to do complex validation. Deepcopy does not copy these functions properly - see https://github.com/esnet/esnet-esdb/issues/634.

This change simply sets back the function after copying the object. I also added docs and an example for using custom validation functions.